### PR TITLE
Move player objects and actions back into the game1 class.

### DIFF
--- a/Sprintfinity3902/Commands/SetDamageLinkCommand.cs
+++ b/Sprintfinity3902/Commands/SetDamageLinkCommand.cs
@@ -1,5 +1,6 @@
 ﻿using Sprintfinity3902.Interfaces;
 using Sprintfinity3902.Link;
+using Sprintfinity3902.Maps;
 
 namespace Sprintfinity3902.Commands
 {
@@ -20,7 +21,7 @@ namespace Sprintfinity3902.Commands
 
         public void Execute()
         {
-             game.playerCharacter.TakeDamage();
+            game.playerCharacter.TakeDamage();
             damagedLink = new DamagedLink(decoratedLink, game);
             game.playerCharacter = damagedLink;
         }

--- a/Sprintfinity3902/Commands/SetDamageLinkCommand.cs
+++ b/Sprintfinity3902/Commands/SetDamageLinkCommand.cs
@@ -1,6 +1,5 @@
 ﻿using Sprintfinity3902.Interfaces;
 using Sprintfinity3902.Link;
-using Sprintfinity3902.Maps;
 
 namespace Sprintfinity3902.Commands
 {

--- a/Sprintfinity3902/Entities/Link/DamagedLink.cs
+++ b/Sprintfinity3902/Entities/Link/DamagedLink.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Sprintfinity3902.Interfaces;
+using Sprintfinity3902.Maps;
 
 
 namespace Sprintfinity3902.Link
@@ -64,7 +65,7 @@ namespace Sprintfinity3902.Link
         }
         
 
-        public DamagedLink (Player decoratedLink, Game1 game)
+        public DamagedLink (Player decoratedLink,Game1 game)
         {
             this.decoratedLink = decoratedLink;
             this.game = game;

--- a/Sprintfinity3902/Entities/Link/DamagedLink.cs
+++ b/Sprintfinity3902/Entities/Link/DamagedLink.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Sprintfinity3902.Interfaces;
-using Sprintfinity3902.Maps;
-
 
 namespace Sprintfinity3902.Link
 {

--- a/Sprintfinity3902/Game1.cs
+++ b/Sprintfinity3902/Game1.cs
@@ -6,6 +6,9 @@ using Sprintfinity3902.Interfaces;
 using Sprintfinity3902.Maps;
 using Sprintfinity3902.Navigation;
 using Sprintfinity3902.SpriteFactories;
+using Sprintfinity3902.Link;
+using Sprintfinity3902.Commands;
+using Sprintfinity3902.Entities;
 
 namespace Sprintfinity3902
 {
@@ -17,7 +20,13 @@ namespace Sprintfinity3902
         public static int ScaleWindow = 7;
         public GraphicsDeviceManager Graphics { get { return graphics; } }
 
+
         public ILink playerCharacter;
+        private Player link;
+        private IEntity boomerangItem;
+        private IEntity bombItem;
+        private IEntity movingSword;
+
 
         private Map sprintTwo; 
 
@@ -40,7 +49,26 @@ namespace Sprintfinity3902
         protected void Reset() {
             KeyboardManager.Instance.Reset();
 
-            sprintTwo.Setup();
+
+
+            sprintTwo.Setup(this);
+
+            playerCharacter = new Player();
+            link = (Player)playerCharacter;
+
+            boomerangItem = new BoomerangItem();
+            bombItem = new BombItem(new Vector2(-1000, -1000));
+            movingSword = new MovingSwordItem(new Vector2(-1000, -1000));
+
+            KeyboardManager.Instance.Initialize(link);
+
+            KeyboardManager.Instance.RegisterKeyUpCallback(() => { link.CurrentState.Sprite.Animation.Stop(); }, Keys.W, Keys.A, Keys.S, Keys.D, Keys.Up, Keys.Down, Keys.Left, Keys.Right);
+
+            KeyboardManager.Instance.RegisterCommand(new SetDamageLinkCommand(this), Keys.E);
+            KeyboardManager.Instance.RegisterCommand(new UseBombCommand((Player)playerCharacter, (BombItem)bombItem), Keys.D1);
+            KeyboardManager.Instance.RegisterCommand(new UseBoomerangCommand((Player)playerCharacter, (BoomerangItem)boomerangItem), Keys.D2);
+            KeyboardManager.Instance.RegisterCommand(new SetLinkAttackCommand((Player)playerCharacter, (MovingSwordItem)movingSword), Keys.Z, Keys.N);
+
 
             KeyboardManager.Instance.RegisterKeyUpCallback(Exit, Keys.Q);
             KeyboardManager.Instance.RegisterKeyUpCallback(Reset, Keys.R);
@@ -66,6 +94,11 @@ namespace Sprintfinity3902
 
             sprintTwo.Update(gameTime);
 
+            playerCharacter.Update(gameTime);
+            boomerangItem.Update(gameTime);
+            bombItem.Update(gameTime);
+            movingSword.Update(gameTime);
+
             base.Update(gameTime);
         }
 
@@ -75,6 +108,13 @@ namespace Sprintfinity3902
 
             Camera.Instance.Draw(SpriteBatch);
             sprintTwo.Draw(SpriteBatch);
+
+
+            playerCharacter.Draw(SpriteBatch, Color.White);
+
+            boomerangItem.Draw(SpriteBatch);
+            bombItem.Draw(SpriteBatch);
+            movingSword.Draw(SpriteBatch);
 
             SpriteBatch.End();
 

--- a/Sprintfinity3902/Game1.cs
+++ b/Sprintfinity3902/Game1.cs
@@ -28,7 +28,7 @@ namespace Sprintfinity3902
         private IEntity movingSword;
 
 
-        private Map sprintTwo; 
+        private IMap sprintTwo; 
 
         public Game1() {
             graphics = new GraphicsDeviceManager(this);
@@ -37,7 +37,7 @@ namespace Sprintfinity3902
             IsMouseVisible = true;
 
             Camera.Instance.SetWindowBounds(graphics);
-            sprintTwo = new SprintTwo();
+            sprintTwo = new DefaultMap();
 
             Graphics.ApplyChanges();
         }

--- a/Sprintfinity3902/Interfaces/IMap.cs
+++ b/Sprintfinity3902/Interfaces/IMap.cs
@@ -1,6 +1,6 @@
 ﻿namespace Sprintfinity3902.Interfaces
 {
-    public interface Map : IDrawable, IUpdateable {
+    public interface IMap : IDrawable, IUpdateable {
 
         public void Setup(Game1 gameInstance);
     }

--- a/Sprintfinity3902/Interfaces/Map.cs
+++ b/Sprintfinity3902/Interfaces/Map.cs
@@ -1,6 +1,7 @@
 ﻿namespace Sprintfinity3902.Interfaces
 {
     public interface Map : IDrawable, IUpdateable {
-        public void Setup();
+
+        public void Setup(Game1 gameInstance);
     }
 }

--- a/Sprintfinity3902/Maps/DefaultMap.cs
+++ b/Sprintfinity3902/Maps/DefaultMap.cs
@@ -1,16 +1,14 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using Sprintfinity3902.Commands;
 using Sprintfinity3902.Controllers;
 using Sprintfinity3902.Entities;
 using Sprintfinity3902.Interfaces;
-using Sprintfinity3902.Link;
 using System.Collections.Generic;
 
 namespace Sprintfinity3902.Maps
 {
-    public class SprintTwo : Map
+    public class DefaultMap : IMap
     {
 
         private List<IEntity> cyclableBlocks;
@@ -23,7 +21,7 @@ namespace Sprintfinity3902.Maps
 
         private IEntity goriyaBoomerang;
 
-        public SprintTwo()
+        public DefaultMap()
         {
 
             //cyclableBlocks = new List<IEntity>();

--- a/Sprintfinity3902/Maps/SprintTwo.cs
+++ b/Sprintfinity3902/Maps/SprintTwo.cs
@@ -21,26 +21,24 @@ namespace Sprintfinity3902.Maps
         private int itemIndex;
         private int NPCIndex;
 
-        public ILink playerCharacter;
-        private IEntity boomerangItem;
-        private IEntity bombItem;
-        private IEntity movingSword;
         private IEntity goriyaBoomerang;
 
         public SprintTwo()
         {
 
-            cyclableBlocks = new List<IEntity>();
-            cyclableItems = new List<IEntity>();
-            cyclableCharacters = new List<IEntity>();
+            //cyclableBlocks = new List<IEntity>();
+            //cyclableItems = new List<IEntity>();
+            //cyclableCharacters = new List<IEntity>();
         }
 
-        public void Setup()
+        public void Setup(Game1 gameInstance)
         {
-            KeyboardManager.Instance.Reset();
 
             goriyaBoomerang = new BoomerangItem();
 
+            cyclableBlocks = new List<IEntity>();
+            cyclableItems = new List<IEntity>();
+            cyclableCharacters = new List<IEntity>();
 
             cyclableItems.Add(new RupeeItem(new Vector2(500, 300)));
             cyclableItems.Add(new HeartItem(new Vector2(500, 300)));
@@ -72,24 +70,11 @@ namespace Sprintfinity3902.Maps
             cyclableBlocks.Add(new BlackBlock());
             cyclableBlocks.Add(new SpottedBlock());
             cyclableBlocks.Add(new DarkBlueBlock());
-            playerCharacter = new Player();
-
-            boomerangItem = new BoomerangItem();
-            bombItem = new BombItem(new Vector2(-1000, -1000));
-            movingSword = new MovingSwordItem(new Vector2(-1000, -1000));
-
-            KeyboardManager.Instance.Initialize((Player)playerCharacter);
-
-            KeyboardManager.Instance.RegisterKeyUpCallback(() => { ((Player)playerCharacter).CurrentState.Sprite.Animation.Stop(); }, Keys.W, Keys.A, Keys.S, Keys.D, Keys.Up, Keys.Down, Keys.Left, Keys.Right, Keys.E);
 
             blockIndex = KeyboardManager.Instance.CreateNewDeltaKeys(Keys.T, Keys.Y);
             itemIndex = KeyboardManager.Instance.CreateNewDeltaKeys(Keys.U, Keys.I);
             NPCIndex = KeyboardManager.Instance.CreateNewDeltaKeys(Keys.O, Keys.P);
 
-            // KeyboardManager.Instance.RegisterCommand(new SetDamageLinkCommand(this), Keys.E);
-            KeyboardManager.Instance.RegisterCommand(new UseBombCommand((Player)playerCharacter, (BombItem)bombItem), Keys.D1);
-            KeyboardManager.Instance.RegisterCommand(new UseBoomerangCommand((Player)playerCharacter, (BoomerangItem)boomerangItem), Keys.D2);
-            KeyboardManager.Instance.RegisterCommand(new SetLinkAttackCommand((Player)playerCharacter, (MovingSwordItem)movingSword), Keys.Z, Keys.N);
         }
 
 
@@ -99,11 +84,6 @@ namespace Sprintfinity3902.Maps
             cyclableBlocks[KeyboardManager.Instance.GetCountDeltaKey(blockIndex, cyclableBlocks.Count)].Update(gameTime);
             cyclableItems[KeyboardManager.Instance.GetCountDeltaKey(itemIndex, cyclableItems.Count)].Update(gameTime);
             cyclableCharacters[KeyboardManager.Instance.GetCountDeltaKey(NPCIndex, cyclableCharacters.Count)].Update(gameTime);
-
-            playerCharacter.Update(gameTime);
-            boomerangItem.Update(gameTime);
-            bombItem.Update(gameTime);
-            movingSword.Update(gameTime);
         }
 
         public void Draw(SpriteBatch spriteBatch)
@@ -113,11 +93,6 @@ namespace Sprintfinity3902.Maps
             cyclableItems[KeyboardManager.Instance.GetCountDeltaKey(itemIndex, cyclableItems.Count)].Draw(spriteBatch);
             cyclableCharacters[KeyboardManager.Instance.GetCountDeltaKey(NPCIndex, cyclableCharacters.Count)].Draw(spriteBatch);
 
-            playerCharacter.Draw(spriteBatch, Color.White);
-
-            boomerangItem.Draw(spriteBatch);
-            bombItem.Draw(spriteBatch);
-            movingSword.Draw(spriteBatch);
 
         }
 


### PR DESCRIPTION
This is a fix for issues involving bugs that were created the game1 class was cleaned. This reserves the map entities to strictly implementing the items that will be on the given map. Generally this improves the focus of the map class.

This moves things like registering commands back into the game1 class for ease of interaction with damaged link.